### PR TITLE
Fix bounds

### DIFF
--- a/matrixMul.cu
+++ b/matrixMul.cu
@@ -35,10 +35,12 @@ __global__ void MatrixMulCUDA(float *C, float *A, float *B, int wA, int wB,
 
   float Csub[total_elements] = {0.0f};
 
+
+  __shared__ float As[ELEMENTS_PER_THREAD_X * BLOCK_SIZE][BLOCK_SIZE];
+  __shared__ float Bs[BLOCK_SIZE][ELEMENTS_PER_THREAD_Y * BLOCK_SIZE];
+
   for (int a = aBegin, b = bBegin; a <= aEnd; a += aStep, b += bStep) {
 
-    __shared__ float As[ELEMENTS_PER_THREAD_X * BLOCK_SIZE][BLOCK_SIZE];
-    __shared__ float Bs[BLOCK_SIZE][ELEMENTS_PER_THREAD_Y * BLOCK_SIZE];
 
 #pragma unroll
     for (int i = 0; i < ELEMENTS_PER_THREAD_X; i++) {
@@ -291,16 +293,13 @@ int main(int argc, char **argv) {
     printf("      -wB=WidthB -hB=HeightB (Width x Height of Matrix B)\n");
     printf("  Note: Outer matrix dimensions of A & B matrices"
            " must be equal.\n");
-    printf("      -blocksize=n (n = 16 or 32, default is 16)\n");
-    printf(
-        "      -elements_per_thread=n (n = 1, 2, 4, 8, etc., default is 4)\n");
-
+    printf("-blocksize=n (n = 16 or 32, default is 16)\n");
     exit(EXIT_SUCCESS);
   }
 
   int dev = findCudaDevice(argc, (const char **)argv);
 
-  int block_size = 16;
+  int block_size = 32;
 
   if (checkCmdLineFlag(argc, (const char **)argv, "blocksize")) {
     block_size = getCmdLineArgumentInt(argc, (const char **)argv, "blocksize");

--- a/matrixMul.cu
+++ b/matrixMul.cu
@@ -10,10 +10,10 @@
 #include "helper_functions.h"
 
 #define ELEMENTS_PER_THREAD_X                                                  \
-  8 // Number of elements that each thread will process sequentially (in
+  6 // Number of elements that each thread will process sequentially (in
     // separate X Blocks)
 #define ELEMENTS_PER_THREAD_Y                                                  \
-  2 // Number of elements that each thread will process sequentially (in
+  6 // Number of elements that each thread will process sequentially (in
     // separate Y Blocks)
 
 template <int BLOCK_SIZE>
@@ -189,7 +189,7 @@ int MatrixMultiply(int argc, char **argv, int block_size, const dim3 &dimsA,
 
   checkCudaErrors(cudaEventRecord(start, stream));
 
-  int nIter = 1;
+  int nIter = 30;
 
   for (int j = 0; j < nIter; j++) {
     if (block_size == 16) {
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
 
   int dev = findCudaDevice(argc, (const char **)argv);
 
-  int block_size = 32;
+  int block_size = 16;
 
   if (checkCmdLineFlag(argc, (const char **)argv, "blocksize")) {
     block_size = getCmdLineArgumentInt(argc, (const char **)argv, "blocksize");

--- a/matrixMul.cu
+++ b/matrixMul.cu
@@ -10,10 +10,10 @@
 #include "helper_functions.h"
 
 #define ELEMENTS_PER_THREAD_X                                                  \
-  6 // Number of elements that each thread will process sequentially (in
+  4 // Number of elements that each thread will process sequentially (in
     // separate X Blocks)
 #define ELEMENTS_PER_THREAD_Y                                                  \
-  6 // Number of elements that each thread will process sequentially (in
+  4 // Number of elements that each thread will process sequentially (in
     // separate Y Blocks)
 
 template <int BLOCK_SIZE>
@@ -40,31 +40,16 @@ __global__ void MatrixMulCUDA(float *C, float *A, float *B, int wA, int wB,
     __shared__ float As[ELEMENTS_PER_THREAD_X * BLOCK_SIZE][BLOCK_SIZE];
     __shared__ float Bs[BLOCK_SIZE][ELEMENTS_PER_THREAD_Y * BLOCK_SIZE];
 
-    // Bs[ty][tx] = B[b + wB * ty + tx];
-#pragma unroll // pragma unroll -- compiler directive to try to unroll the loop
+#pragma unroll
     for (int i = 0; i < ELEMENTS_PER_THREAD_X; i++) {
       int row = ty + i * BLOCK_SIZE;
-      int col = a + tx;
-      if (row < hA && col < wA) {
-        As[ty + i * BLOCK_SIZE][tx] =
-            A[a + wA * (ty + i * BLOCK_SIZE) +
-              tx]; //  i * BLOCK_SIZE -> stride for blocks
-      } else {
-        As[ty + i * BLOCK_SIZE][tx] = 0.0f;
-      }
+      int col = tx;
+      As[row][tx] = A[a + wA * row + col]; 
     }
 #pragma unroll
     for (int i = 0; i < ELEMENTS_PER_THREAD_Y; i++) {
-      const int row = (b / wB) + ty; // phase / slice + thread row (threadX ->
-                                     // on Y axis , threadY -> on X axis)
-      const int col = tx + i * BLOCK_SIZE;
-      if (row < wB && col < wB) {
-        Bs[ty][col] = B[row * wB + col];
-      } else {
-        Bs[ty][col] = 0.0f;
-      }
-      // Bs[ty][col] = B[b + (wB * ty) + col]; //  i * BLOCK_SIZE -> stride for
-      // blocks
+      int col = tx + i * BLOCK_SIZE;
+      Bs[ty][col] = B[b + (wB * ty) + col];
     }
 
     __syncthreads();
@@ -86,9 +71,7 @@ __global__ void MatrixMulCUDA(float *C, float *A, float *B, int wA, int wB,
     for (int j = 0; j < ELEMENTS_PER_THREAD_Y; j++) {
       int row = (by * BLOCK_SIZE * ELEMENTS_PER_THREAD_X) + ty + i * BLOCK_SIZE;
       int col = (bx * BLOCK_SIZE * ELEMENTS_PER_THREAD_Y) + tx + j * BLOCK_SIZE;
-      if (row < hA && col < wB) {
-        C[row * wB + col] = Csub[j + i * ELEMENTS_PER_THREAD_Y];
-      }
+      C[row * wB + col] = Csub[j + i * ELEMENTS_PER_THREAD_Y];
     }
   }
 }
@@ -171,10 +154,13 @@ int MatrixMultiply(int argc, char **argv, int block_size, const dim3 &dimsA,
 
   dim3 threads(block_size, block_size);
 
-  int grid_x = (dimsB.x + ELEMENTS_PER_THREAD_Y * threads.x - 1) /
-               (ELEMENTS_PER_THREAD_Y * threads.x);
-  int grid_y = (dimsA.y + ELEMENTS_PER_THREAD_X * threads.y - 1) /
-               (ELEMENTS_PER_THREAD_X * threads.y);
+  // int grid_x = (dimsB.x + ELEMENTS_PER_THREAD_Y * threads.x - 1) /
+  //              (ELEMENTS_PER_THREAD_Y * threads.x);
+  // int grid_y = (dimsA.y + ELEMENTS_PER_THREAD_X * threads.y - 1) /
+  //              (ELEMENTS_PER_THREAD_X * threads.y);
+
+  int grid_x = dimsB.x / threads.x / ELEMENTS_PER_THREAD_Y;
+  int grid_y = dimsA.y / threads.y / ELEMENTS_PER_THREAD_X;
 
   dim3 grid(grid_x, grid_y, 1);
 
@@ -299,7 +285,7 @@ int main(int argc, char **argv) {
 
   int dev = findCudaDevice(argc, (const char **)argv);
 
-  int block_size = 16;
+  int block_size = 32;
 
   if (checkCmdLineFlag(argc, (const char **)argv, "blocksize")) {
     block_size = getCmdLineArgumentInt(argc, (const char **)argv, "blocksize");
@@ -364,7 +350,7 @@ int main(int argc, char **argv) {
          (int)((dimsA.y + ELEMENTS_PER_THREAD_X * block_size - 1) /
                (ELEMENTS_PER_THREAD_X * block_size)));
   printf("BLOCK SIZE: (%d, %d)\n", block_size, block_size);
-  printf("EACH BLOCK PROCESS %d ROWS\n", ELEMENTS_PER_THREAD_X * block_size);
+  printf("EACH THREAD WILL FETCH %d ROWS\n", ELEMENTS_PER_THREAD_X * block_size);
   printf("ALL BLOCKS IN Y : %d, X : %d\n",
          (int)((dimsA.y + ELEMENTS_PER_THREAD_X * block_size - 1) /
                (ELEMENTS_PER_THREAD_X * block_size)),

--- a/matrixMul.cu
+++ b/matrixMul.cu
@@ -55,11 +55,11 @@ __global__ void MatrixMulCUDA(float *C, float *A, float *B, int wA, int wB,
     }
 #pragma unroll
     for (int i = 0; i < ELEMENTS_PER_THREAD_Y; i++) {
-      const int row = b + (wB * ty);       
+      const int row = (b / wB) + ty; // phase / slice + thread row (threadX ->
+                                     // on Y axis , threadY -> on X axis)
       const int col = tx + i * BLOCK_SIZE;
       if (row < wB && col < wB) {
-        Bs[ty][col] =
-            B[b + (wB * ty) + col]; //  i * BLOCK_SIZE -> stride for blocks
+        Bs[ty][col] = B[row * wB + col];
       } else {
         Bs[ty][col] = 0.0f;
       }


### PR DESCRIPTION
This pull request introduces several updates to the `matrixMul.cu` file, focusing on improving performance, enhancing error reporting, and refining initialization and configuration. The most significant changes include optimizing the CUDA kernel, adding a new random initialization function, improving error reporting, and modifying default parameters for better usability.

### CUDA Kernel Optimization:
* Simplified the shared memory access logic in the CUDA kernel by removing boundary checks and directly assigning values, potentially improving performance. (`MatrixMulCUDA` function)

### Initialization Enhancements:
* Added a new `RandomInit` function for initializing matrices with random values, replacing the previous gradient and constant initialization in the `MatrixMultiply` function. (`RandomInit` and `MatrixMultiply` functions) [[1]](diffhunk://#diff-0125c62c4d72a35c67edd775de9c8a6f0d6f72f9f0f98742583e152086665cbeR89-R94) [[2]](diffhunk://#diff-0125c62c4d72a35c67edd775de9c8a6f0d6f72f9f0f98742583e152086665cbeL137-R131)

### Error Reporting Improvements:
* Introduced an `error_count` variable to track the total number of errors during result validation and print the count if any errors are found. (`MatrixMultiply` function) [[1]](diffhunk://#diff-0125c62c4d72a35c67edd775de9c8a6f0d6f72f9f0f98742583e152086665cbeR242) [[2]](diffhunk://#diff-0125c62c4d72a35c67edd775de9c8a6f0d6f72f9f0f98742583e152086665cbeR251) [[3]](diffhunk://#diff-0125c62c4d72a35c67edd775de9c8a6f0d6f72f9f0f98742583e152086665cbeR261-R263)

### Parameter and Configuration Changes:
* Updated the default block size to 32 (from 16) for better performance on modern GPUs. (`main` function)
* Enhanced the output logs to include more detailed information about thread and block configurations, improving debugging and analysis. (`main` function)

These changes collectively aim to improve the performance, usability, and robustness of the matrix multiplication CUDA implementation.